### PR TITLE
adapting to new version of autograd

### DIFF
--- a/recnn/recnn.py
+++ b/recnn/recnn.py
@@ -1,5 +1,5 @@
 import autograd.numpy as np
-from autograd.util import flatten_func
+from autograd.misc.flatten import flatten_func
 from sklearn.utils import check_random_state
 
 


### PR DESCRIPTION
the flatten_func function has been moved to another module in autograd, just adapting to this change so that train.py can run